### PR TITLE
Implement auto-merge bot functionality

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -17,3 +17,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: scripts/triage
+    - name: auto-merge
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      run: scripts/auto-merge

--- a/scripts/auto-merge
+++ b/scripts/auto-merge
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+from github import Github
+import os
+
+# Initialize Github
+github = Github(os.environ['GITHUB_TOKEN'])
+
+# Print column keys.
+print(" Merged? | Repository + PR number | Mergeable? | State  ")
+
+for issue in github.search_issues("org:enarx state:open is:public is:pr review:approved"):
+    # Status strings.
+    merged_indicator = "✗"
+    pr_identifier = f"{issue.repository.name}#{issue.number}"
+
+    # `search_issues()` returns issues. Convert to PRs.
+    pr = issue.as_pull_request()
+    
+    # If all merge criteria pass, merge the PR.
+    if pr.mergeable and pr.mergeable_state == "clean":
+        merged_indicator = "✓"
+        pr.merge(merge_method="rebase")
+
+    # List the status of the pull request.
+    print(f" {merged_indicator:8}| {pr_identifier:23}| {str(pr.mergeable):11}| {pr.mergeable_state:7}")


### PR DESCRIPTION
This code implements auto-merge for the Enarx organization bot.

While functionally complete, I'm submitting in draft form until I know the name of the encrypted secret to use (currently `secrets.BOT_TOKEN`).

The code is intended to run every 15 minutes (with `cron` syntax). For faster testing, it's currently set to run every 5 minutes. When run, it will leave logs about which PRs were and were not auto-merged.

It currently runs on the [enarxbot-test-org](https://github.com/enarxbot-test-org) organization for testing.