### PR TITLE
Implement an hourly triage workflow

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -1,0 +1,19 @@
+name: hourly
+
+on:
+  schedule:
+    - cron:  '58 * * * *'
+
+jobs:
+  hourly:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: |
+        /usr/bin/python3 -m pip install --upgrade pip setuptools
+        /usr/bin/python3 -m pip install PyGithub
+    - name: triage
+      env:
+        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      run: scripts/triage

--- a/scripts/triage
+++ b/scripts/triage
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+from github import Github
+import os
+
+github = Github(os.environ['GITHUB_TOKEN'])
+org = github.get_organization('enarx')
+project = [p for p in org.get_projects(state='open') if p.name == 'Planning'][0]
+column = [c for c in project.get_columns() if c.name == 'Triage'][0]
+
+for issue in github.search_issues(f"org:enarx state:open is:public -project:enarx/{project.number}"):
+    content_id = issue.id if issue.pull_request is None else issue.as_pull_request().id
+    content_type = 'Issue' if issue.pull_request is None else 'PullRequest'
+    column.create_card(content_id=content_id, content_type=content_type)


### PR DESCRIPTION
This workflow searches for all issues which are not in the `Planning`
project and adds them to the project in the `Triage` column. We do this
at the bottom of the hour so that the `Triage` column is fresh for any
meetings we might have to do triage.