### PR TITLE
Rewrite prstate action

### DIFF
--- a/scripts/prstate
+++ b/scripts/prstate
@@ -6,18 +6,38 @@ import os
 
 github = Github(os.environ['GITHUB_TOKEN'])
 
-for issue in github.search_issues(f"org:enarx state:open is:public is:pr"):
-    pr = issue.as_pull_request()
-
-    reviewers = {r.user.login for r in pr.get_reviews() if r.state == 'CHANGES_REQUESTED'}
-    requested = {r.login for r in pr.get_review_requests()[0]}
+def handle(issue, pr, responsible):
     assignees = {a.login for a in pr.assignees}
 
-    remove = reviewers - requested
-    needed = requested | ({pr.user.login} if remove else set())
+    remove = assignees - responsible
+    needed = responsible - assignees
 
-    remove &= assignees
-    needed -= assignees
+    repo = issue.repository
+    print(f"{repo.organization.login}/{repo.name}#{pr.number}:", end='')
+    for u in needed:
+        print(f" +{u}", end='')
+    for u in remove:
+        print(f" -{u}", end='')
+    print()
 
-    pr.remove_from_assignees(*remove)
-    pr.add_to_assignees(*needed)
+    if remove:
+        pr.remove_from_assignees(*remove)
+    if needed:
+        pr.add_to_assignees(*needed)
+
+# If there are any changes requested, the author is responsible.
+for issue in github.search_issues(f"org:enarx is:pr is:public is:open -is:draft review:changes_requested"):
+    pr = issue.as_pull_request()
+
+    handle(issue, pr, {pr.user.login})
+
+# Otherwise, requested reviewers and reviewers with dismissed reviews are.
+# This handles both where the author requests re-review and where, after
+# approvals, reviews were dismissed due to a new push.
+for issue in github.search_issues(f"org:enarx is:pr is:public is:open -is:draft -review:changes_requested"):
+    pr = issue.as_pull_request()
+
+    dismissed = {r.user.login for r in pr.get_reviews() if r.state == 'DISMISSED'}
+    requested = {r.login for r in pr.get_review_requests()[0]}
+
+    handle(issue, pr, dismissed | requested)


### PR DESCRIPTION
After thinking on this a bit, I want to move to a simpler responsibility
model. While there are any outstanding `CHANGES_REQUESTED`, the PR is
the responsiblity of the author. Otherwise, the PR is the responsibility
of the people who have been requested for review and the previous
reviewers who have had their reviews `DISMISSED`. The latter condition
captures reviewers who have accepted a PR, but then the author pushed
additional changes. In this case, the reviewer must re-review.

This responsibility model also has the nice property that reviewers
aren't responsible to re-review a PR until the author addresses all
outstanding reviews. Without this, reviews might become interleaved
which could result in conflicting requirements and a general increase of
disruption of engineer thought patterns.