### PR TITLE
Enable a local caching proxy for all bot requests

### DIFF
--- a/.github/workflows/hourly.yml
+++ b/.github/workflows/hourly.yml
@@ -7,25 +7,19 @@ on:
 jobs:
   hourly:
     runs-on: ubuntu-latest
+    container: quay.io/enarx/bot
+    env:
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      PROXY_API_URL: http://localhost
     steps:
     - uses: actions/checkout@v2
-    - name: dependencies
-      run: |
-        /usr/bin/python3 -m pip install --upgrade pip setuptools
-        /usr/bin/python3 -m pip install PyGithub
+    - name: nginx
+      run: nginx -c /etc/nginx/nginx.conf -g 'pid /var/run/nginx.pid;'
     - name: triage
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: scripts/triage
     - name: merge
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: scripts/merge
     - name: prstate
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: scripts/prstate
     - name: assigned
-      env:
-        GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       run: scripts/assigned

--- a/scripts/assigned
+++ b/scripts/assigned
@@ -1,10 +1,9 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import common
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = common.github()
 org = github.get_organization('enarx')
 
 project = {p.name: p for p in org.get_projects(state='open')}['Sprint']

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+def github():
+    import github
+    import os
+
+    url = github.MainClass.DEFAULT_BASE_URL
+    url = os.environ.get('GITHUB_API_URL', url)
+    url = os.environ.get('PROXY_API_URL', url)
+
+    token = os.environ['GITHUB_TOKEN']
+
+    return github.Github(token, base_url=url)

--- a/scripts/merge
+++ b/scripts/merge
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import common
 
 # Initialize Github
-github = Github(os.environ['GITHUB_TOKEN'])
+github = common.github()
 
 # Print column keys.
 print(" Merged? | Repository + PR number | Mergeable? | State  ")

--- a/scripts/prstate
+++ b/scripts/prstate
@@ -1,10 +1,9 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import common
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = common.github()
 
 def handle(issue, pr, responsible):
     assignees = {a.login for a in pr.assignees}

--- a/scripts/triage
+++ b/scripts/triage
@@ -1,10 +1,10 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import common
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = common.github()
+
 org = github.get_organization('enarx')
 project = [p for p in org.get_projects(state='open') if p.name == 'Planning'][0]
 column = [c for c in project.get_columns() if c.name == 'Triage'][0]


### PR DESCRIPTION
We use the bot container which has pygithub and nginx set up for us.
Then we proxy all requests through the nginx proxy. Repeated requests
will be cached. This increases performance and reduces the number of API
calls we make all the way to GitHub's servers.