### PR TITLE
Implement an action for manual end-of-sprint board cleanup

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,22 @@
+name: manual
+
+on: 
+  workflow_dispatch
+
+jobs:
+  manual:
+    runs-on: ubuntu-latest
+    container: quay.io/enarx/bot
+    env:
+      NSS_WRAPPER_HOSTS: /etc/nginx/hosts.conf
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+    steps:
+    - name: certificate
+      run: |
+        openssl req -x509 -newkey rsa:4096 -keyout /etc/nginx/api.github.com.key -out /etc/nginx/api.github.com.crt -days 1 -subj '/CN=api.github.com' -addext "subjectAltName = DNS:api.github.com" -nodes
+        cp /etc/nginx/api.github.com.crt /etc/pki/ca-trust/source/anchors/
+        update-ca-trust
+    - name: nginx
+      run: nginx -c /etc/nginx/nginx.conf
+    - name: post-sprint-cleanup
+      run: LD_PRELOAD=libnss_wrapper.so enarx-post-sprint-cleanup

--- a/enarx-post-sprint-cleanup
+++ b/enarx-post-sprint-cleanup
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+import enarxbot
+
+github = enarxbot.connect()
+org = github.get_organization('enarx')
+
+sprint = {p.name: p for p in org.get_projects(state='open')}['Sprint']
+sprint_columns = {c.name: c for c in sprint.get_columns()}
+planning = {p.name: p for p in org.get_projects(state='open')}['Planning']
+planning_columns = {c.name: c for c in planning.get_columns()}
+
+for assigned_card in sprint_columns['Assigned'].get_cards():
+    issue = assigned_card.get_content(content_type="Issue")
+    if issue is not None:
+        # If a valid issue, we want to move it to Nominated in Planning.
+        # First, check if a card for this issue already exists. If yes, move it
+        # instead of creating a new card.
+        for column in planning_columns:
+            for card in column.get_cards():
+                if card.get_content("Issue") is not None and card.get_content("Issue").id == issue.id:
+                    card.move(position="bottom", column=planning_columns['Nominated'])
+                    continue
+        # If the loop didn't find any matching cards, create a new one.
+        enarxbot.create_card(planning_columns['Nominated'], issue.id, "Issue")
+
+        # Once we're done moving/creating the cards, delete the one on the
+        # Sprint board.
+        assigned_card.delete()


### PR DESCRIPTION
This action is triggered manually, under the "Actions" tab of the `enarx/bot` repo. It moves all issues in the "Assigned" tab of the sprint board to the "Nominated" tab; intended to be used at end-of-sprint retrospectives.

This needs #20 in order to work correctly; otherwise, issues will be automatically moved back to the Sprint board if they're still assigned.

Resolves #17.