### PR TITLE
Ensure merge order

### DIFF
--- a/enarx-pr-merge
+++ b/enarx-pr-merge
@@ -8,8 +8,9 @@ github = enarxbot.connect()
 
 # Print column keys.
 print(" Merged? | Repository + PR number | Mergeable? | State  ")
+print("-------------------------------------------------------")
 
-for issue in github.search_issues("org:enarx state:open is:public is:pr review:approved"):
+for issue in github.search_issues("org:enarx state:open is:public is:pr review:approved sort:created-asc"):
     # Status strings.
     merged_indicator = "✗"
     pr_identifier = f"{issue.repository.name}#{issue.number}"


### PR DESCRIPTION
This PR rewrites the `merge` action to merge PRs in ascending order of the time of last approval.

It's a little messy, I haven't tested it yet, and it may need changes, so I'm submitting in draft form.

Resolves #30.