### PR TITLE
Make project card additions fail gracefully

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ COPY github.conf /etc/nginx/conf.d/github.conf
 COPY hosts.conf /etc/nginx/hosts.conf
 
 COPY enarx-* /usr/local/bin/
+COPY enarxbot.py /usr/local/lib/python3.8/site-packages/

--- a/enarx-assigned
+++ b/enarx-assigned
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from github import Github
+import enarxbot
 import os
 
 github = Github(os.environ['GITHUB_TOKEN'])
@@ -12,10 +13,10 @@ columns = {c.name: c for c in project.get_columns()}
 
 for issue in github.search_issues(f"org:enarx is:issue state:open is:public -label:conference -project:enarx/{project.number}"):
     if issue.assignee is not None:
-        columns['Assigned'].create_card(content_id=issue.id, content_type='Issue')
+        enarxbot.create_card(columns['Assigned'], issue.id, 'Issue')
 
 for issue in github.search_issues(f"org:enarx is:pr state:open is:public -project:enarx/{project.number}"):
     pr = issue.as_pull_request()
 
     if pr.assignee is not None:
-        columns['Reviewing'].create_card(content_id=pr.id, content_type='PullRequest')
+        enarxbot.create_card(columns['Reviewing'], pr.id, 'PullRequest')

--- a/enarx-triage
+++ b/enarx-triage
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from github import Github
+import enarxbot
 import os
 
 github = Github(os.environ['GITHUB_TOKEN'])
@@ -10,7 +11,7 @@ project = [p for p in org.get_projects(state='open') if p.name == 'Planning'][0]
 column = [c for c in project.get_columns() if c.name == 'Triage'][0]
 
 for issue in github.search_issues(f"org:enarx state:open is:public is:pr -project:enarx/{project.number}"):
-    column.create_card(content_id=issue.as_pull_request().id, content_type='PullRequest')
+    enarxbot.create_card(column, issue.as_pull_request().id, 'PullRequest')
 
 for issue in github.search_issues(f"org:enarx state:open is:public is:issue -label:conference -project:enarx/{project.number}"):
-    column.create_card(content_id=issue.id, content_type='Issue')
+    enarxbot.create_card(column, issue.id, 'Issue')

--- a/enarxbot.py
+++ b/enarxbot.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import github
+
+def create_card(column, content_id, content_type):
+    try:	
+        column.create_card(content_id=content_id, content_type=content_type)
+    except github.GithubException as e:	
+        error = e.data["errors"][0]	
+        if error["resource"] != "ProjectCard" or error["code"] != "unprocessable":	
+            raise	
+        print("Card already in project.")


### PR DESCRIPTION
Github seems to sometimes return stale results when looking for issues that are not in a project. This was causing bot failures when we attempted to add such issues to a project they were already in.

This commit adds error handling around those calls, allowing them to fail gracefully.