### PR TITLE
Fix Python import path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY github.conf /etc/nginx/conf.d/github.conf
 COPY hosts.conf /etc/nginx/hosts.conf
 
 COPY enarx-* /usr/local/bin/
-COPY enarxbot.py /usr/local/lib/python3.8/site-packages/
+COPY enarxbot.py /usr/local/lib/python3.9/site-packages/


### PR DESCRIPTION
Container uses Python 3.9 instead of 3.8.