### PR TITLE
Provide a way to query for suggested reviwers

### DIFF
--- a/enarx-assigned
+++ b/enarx-assigned
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
 import enarxbot
-import os
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = enarxbot.connect()
 org = github.get_organization('enarx')
 
 project = {p.name: p for p in org.get_projects(state='open')}['Sprint']

--- a/enarx-merge
+++ b/enarx-merge
@@ -16,7 +16,7 @@ for issue in github.search_issues("org:enarx state:open is:public is:pr review:a
 
     # `search_issues()` returns issues. Convert to PRs.
     pr = issue.as_pull_request()
-    
+
     # If all merge criteria pass, merge the PR.
     if pr.mergeable and pr.mergeable_state == "clean":
         merged_indicator = "✓"

--- a/enarx-merge
+++ b/enarx-merge
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import enarxbot
 
 # Initialize Github
-github = Github(os.environ['GITHUB_TOKEN'])
+github = enarxbot.connect()
 
 # Print column keys.
 print(" Merged? | Repository + PR number | Mergeable? | State  ")

--- a/enarx-prstate
+++ b/enarx-prstate
@@ -1,10 +1,9 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
-import os
+import enarxbot
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = enarxbot.connect()
 
 def handle(issue, pr, responsible):
     assignees = {a.login for a in pr.assignees}

--- a/enarx-triage
+++ b/enarx-triage
@@ -1,11 +1,9 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0
 
-from github import Github
 import enarxbot
-import os
 
-github = Github(os.environ['GITHUB_TOKEN'])
+github = enarxbot.connect()
 org = github.get_organization('enarx')
 project = [p for p in org.get_projects(state='open') if p.name == 'Planning'][0]
 column = [c for c in project.get_columns() if c.name == 'Triage'][0]

--- a/enarxbot.py
+++ b/enarxbot.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import github
+import os
+
+def connect():
+    token = os.environ.get('GITHUB_TOKEN', None)
+    return github.Github(token)
 
 def create_card(column, content_id, content_type):
     try:	

--- a/enarxbot.py
+++ b/enarxbot.py
@@ -8,10 +8,10 @@ def connect():
     return github.Github(token)
 
 def create_card(column, content_id, content_type):
-    try:	
+    try:
         column.create_card(content_id=content_id, content_type=content_type)
-    except github.GithubException as e:	
-        error = e.data["errors"][0]	
-        if error["resource"] != "ProjectCard" or error["code"] != "unprocessable":	
-            raise	
+    except github.GithubException as e:
+        error = e.data["errors"][0]
+        if error["resource"] != "ProjectCard" or error["code"] != "unprocessable":
+            raise
         print("Card already in project.")

--- a/enarxbot.py
+++ b/enarxbot.py
@@ -1,11 +1,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import requests
 import github
 import os
 
 def connect():
     token = os.environ.get('GITHUB_TOKEN', None)
     return github.Github(token)
+
+def graphql(query):
+    token = os.environ.get('GITHUB_TOKEN', None)
+    json = { "query": query }
+    headers = {}
+
+    if token is not None:
+        headers["Authorization"] = f"token {token}"
+
+    reply = requests.post("https://api.github.com/graphql", json=json, headers=headers)
+    if reply.status_code == 200:
+        return reply.json()
+
+    raise Exception(f"Query failed: {reply.status_code}! {query}")
 
 def create_card(column, content_id, content_type):
     try:


### PR DESCRIPTION
This is only available in GitHub's graphql queries. So we create an object that bridges the gap between the v3 and v4 APIs.