### PR TITLE
Install `pycodestyle` Python linter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN dnf -y update
 RUN dnf -y install nginx
 RUN dnf -y install nss_wrapper
 RUN dnf -y install python3-pygithub
+RUN pip install pycodestyle
 
 COPY github.conf /etc/nginx/conf.d/github.conf
 COPY hosts.conf /etc/nginx/hosts.conf


### PR DESCRIPTION
`pycodestyle` is a newer version of the `pep8` linter. We can use it to enforce lints in Python.