### PR TITLE
Assign PRs to their authors on any CHANGES_REQUESTED reviews

### DIFF
--- a/enarx-pr-assign
+++ b/enarx-pr-assign
@@ -4,6 +4,10 @@
 import enarxbot
 import datetime
 
+class Override(Exception):
+    def __init__(self, responsible):
+        self.responsible = responsible
+
 def merge_events_and_reviews(pr):
     "Gets a summary of all events on a PR by merging issue events and reviews."
     def inner(pr):
@@ -28,7 +32,7 @@ def merge_events_and_reviews(pr):
     return sorted(inner(pr), key=lambda x: x["when"])
 
 def get_responsible(pr):
-    "Gets a set of users responsible for a PR."
+    "Yields the users responsible for a PR or raises Override(responsible)."
 
     # Our strategy in this function is to reverse iterate through the events
     # of each PR participant trying to find the most recent event that assigns
@@ -48,7 +52,7 @@ def get_responsible(pr):
             elif what in ("DISMISSED", "PENDING"):
                 yield who
             elif what == "CHANGES_REQUESTED":
-                yield pr.user.login
+                raise Override({pr.user.login})
             elif what == "APPROVED":
                 break # Neither PR author nor reviewer are responsible.
             else:
@@ -61,7 +65,11 @@ for issue in enarxbot.connect().search_issues(f"org:enarx is:pr is:public is:ope
     slug = f"{issue.repository.organization.login}/{issue.repository.name}#{issue.number}"
     pr = issue.as_pull_request()
 
-    responsible = set(get_responsible(pr))
+    try:
+        responsible = set(get_responsible(pr))
+    except Override as e:
+        responsible = set(e.responsible)
+
     assignees = {a.login for a in pr.assignees}
 
     remove = assignees - responsible


### PR DESCRIPTION
Currently, a single CHANGES_REQUESTED review causes the ticket to be assigned
to the PR author and any additional requested reviewers who have not replied.
This has two negative consequences. First, there is no way to clearly place a
PR in the author's responsibility. For example: "Should we close this PR?"
Second, this encourages reviewers to submit reviews on top of ongoing changes
the author might make. This can only create frustration.

Therefore, this patch makes it ONLY the PR author's responsibility whenever a
CHANGES_REQUESTED review is submitted. No further reviews are needed until the
author addresses the current review.