### PR TITLE
Simplify enarx-pr-request and handle busy

### DIFF
--- a/enarx-pr-request
+++ b/enarx-pr-request
@@ -4,59 +4,67 @@
 import enarxbot
 import random
 
+QUERY = """
+query($user:String!) {
+  user(login:$user) {
+    status {
+      indicatesLimitedAvailability
+    }
+  }
+}
+"""
+
+# Moves random users from src to dst until src is exhausted or dst has max users.
+#
+# Randomly selected users who have set their GitHub status to `busy` are removed
+# from src but are not added to dst.
+def migrate(dst, src, max=None):
+    while len(src) > 0 and (max is None or len(dst) < max):
+        one = random.sample(src, 1)[0]
+        src.remove(one)
+
+        status = enarxbot.graphql(QUERY, user=one)["user"]["status"]
+        if status is None or not status["indicatesLimitedAvailability"]:
+            dst.add(one)
+
 github = enarxbot.connect()
 org = github.get_organization("enarx")
+reviews = {t.name: t for t in org.get_teams()}['reviews']
+potential_reviewers = {r.login for r in reviews.get_members()}
 
 # Auto-assign for all PRs in the org.
 for issue in github.search_issues(f"org:enarx is:pr is:public is:open -is:draft"):
     repo = issue.repository
     pr = issue.as_pull_request()
+    suggestions = enarxbot.Suggestion.query(github, repo, pr)
 
-    # First, put the code owner on all code reviews as code owner.
-    owner = github.get_user("npmccallum")
+    # All currently requested reviewers.
+    requested = {r.user.login for r in pr.get_reviews()}
+    requested |= {r.login for r in pr.get_review_requests()[0]}
 
-    # Construct sets of reviewers. Exclude both the code owner and the PR
-    # author.
-    suggested = {s.reviewer for s in enarxbot.Suggestion.query(github, repo, pr)} - {owner} - {pr.user}
-    reviews = {t.name: t for t in org.get_teams()}['reviews']
-    reviews_team = {r for r in reviews.get_members()} - {owner} - {pr.user}
+    # Get our categories.
+    reviewers = potential_reviewers.copy()
+    suggested = {s.reviewer.login for s in suggestions}
+    authors = {pr.user.login}
+    owners = {"npmccallum"}
 
-    # Figure out if currently requested reviewers include the code owner and
-    # two reviewers from the Reviews team.
-    requested_reviewers = {r.user: r for r in pr.get_reviews() if r.user.login != pr.user.login}
-    requested_reviewers = {r for r in requested_reviewers.keys()}
-    requested_reviewers = requested_reviewers | {r for r in pr.get_review_requests()[0]}
-    requested_review_team = requested_reviewers & reviews_team
-    if owner in requested_reviewers and len(requested_review_team) >= 2:
-        continue
+    # Make sure categories are mutually exclusive.
+    reviewers -= authors | owners | suggested
+    suggested -= authors | owners
+    owners -= authors
 
-    # Construct a list of reviewers to request.
-    to_request = set()
-    if owner.login != pr.user.login:
-        to_request.add(owner)
-
-    # If there are valid suggested reviewers, and fewer than two people
-    # from the reviews team requested for review, grab a suggested reviewer.
-    suggested_reviewer = None
-    if len(requested_review_team) < 2 and len(suggested) > 0:
-        suggested_reviewer = random.sample(suggested, 1)[0]
-        to_request.add(suggested_reviewer)
-    reviews_team = reviews_team - {suggested_reviewer}
-
-    # If we're still short, add random reviewers until we hit three.
-    to_request = to_request | requested_reviewers
-    random_to_add = 3 - len(to_request)
-    if random_to_add > 0:
-        random_reviewers = set(random.sample(reviews_team, random_to_add))
-        to_request = to_request | random_reviewers
+    requesting = requested.copy()     # Existing reviewers
+    migrate(requesting, owners)       # Get all owners.
+    migrate(requesting, suggested, 2) # Get some suggested, leave room for non-suggested.
+    migrate(requesting, reviewers, 3) # Get some non-suggested.
+    migrate(requesting, suggested, 3) # Backfill from suggested.
 
     # Print status.
     print(f"{repo.name}#{pr.number}:", end="")
-    for user in sorted(to_request, key=lambda x: x.login):
-        state = "" if user in requested_reviewers else "+"
-        print(f" {state}{user.login}", end="")
+    for user in sorted(requesting):
+        state = "" if user in requested else "+"
+        print(f" {state}{user}", end="")
     print()
 
     # With all three selected, request them as reviewers.
-    to_request = [r.login for r in to_request]
-    pr.create_review_request(reviewers=to_request)
+    pr.create_review_request(reviewers=requesting)


### PR DESCRIPTION
This proposes two new strategies for the script:
  1. Use login strings rather than User objects in the sets.
  2. Make sets mutually exclusive early on.

Based on this, calculating the set of users to request becomes straightforward.

Also, add support for user status. We will not assign busy users.