### PR TITLE
Fix the bot re-requesting everyone already requested on the PR

### DIFF
--- a/enarx-pr-request
+++ b/enarx-pr-request
@@ -67,4 +67,4 @@ for issue in github.search_issues(f"org:enarx is:pr is:public is:open -is:draft"
     print()
 
     # With all three selected, request them as reviewers.
-    pr.create_review_request(reviewers=requesting)
+    pr.create_review_request(reviewers=requesting - requested)


### PR DESCRIPTION
The bot was re-requesting those already requested on the PR. This makes it such that the bot only requests those that are newly requested.