### PR TITLE
Ensure `pr-merge` uses up-to-date `mergeable` information

### DIFF
--- a/enarx-pr-merge
+++ b/enarx-pr-merge
@@ -11,12 +11,13 @@ print(" Merged? | Repository + PR number | Mergeable? | State  ")
 print("-------------------------------------------------------")
 
 for issue in github.search_issues("org:enarx state:open is:public is:pr review:approved sort:created-asc"):
+    repo = issue.repository
     # Status strings.
     merged_indicator = "✗"
     pr_identifier = f"{issue.repository.name}#{issue.number}"
 
     # `search_issues()` returns issues. Convert to PRs.
-    pr = issue.as_pull_request()
+    pr = repo.get_pr(issue.number)
 
     # If all merge criteria pass, merge the PR.
     if pr.mergeable and pr.mergeable_state == "clean":


### PR DESCRIPTION
`pr-merge` fetches all PRs that might be eligible to merge in just one API request. While efficient, it also means the script might use outdated mergeability information when deciding whether to merge a PR. This can cause an API error that causes the script, and thus the entire bot, to fail.

This approach uses more API requests (one more fetch per PR), but will avoid this issue.