### PR TITLE
Convert `enarx-pr-merge` to GraphQL, and make it consumable by other repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,3 +16,5 @@ runs:
       shell: bash
     - run: $GITHUB_ACTION_PATH/enarxbot-assigned
       shell: bash
+    - run: $GITHUB_ACTION_PATH/enarxbot-pr-merge
+      shell: bash

--- a/bot.py
+++ b/bot.py
@@ -107,6 +107,9 @@ def graphql(query, cursors=None, prev_path=None, **kwargs):
     if token is not None:
         headers["Authorization"] = f"token {token}"
 
+    # Opt into preview API fields for PR merge status.
+    headers["Accept"] = "application/vnd.github.merge-info-preview+json"
+
     # Do the request and check for HTTP errors.
     reply = requests.post(url, json=params, headers=headers)
     if reply.status_code != 200:

--- a/enarxbot-pr-merge
+++ b/enarxbot-pr-merge
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+
+import bot
+
+import json
+import sys
+import os
+
+MERGEABLE_QUERY = '''
+query($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(states: OPEN, first: 100, after:$cursor) {
+      pageInfo { endCursor hasNextPage }
+      nodes {
+        id
+        number
+        mergeable
+        mergeStateStatus
+      }
+    }
+  }
+}
+'''
+
+MERGE_MUTATION = '''
+mutation($input: MergePullRequestInput!) {
+  mergePullRequest(input: $input) {
+    __typename
+  }
+}
+'''
+
+if os.environ["GITHUB_EVENT_NAME"] != "schedule":
+  sys.exit(0)
+
+owner, repo = os.environ["GITHUB_REPOSITORY"].split("/")
+cursor = ["repository", "pullRequests"]
+result = bot.graphql(MERGEABLE_QUERY, cursor=cursor, owner=owner, repo=repo)
+
+prs = {i["id"]: i for i in result["repository"]["pullRequests"]["nodes"]}
+
+# Print column keys.
+print(" Expected to merge? | Repository + PR number | Mergeable? | State  ")
+print("-------------------------------------------------------")
+
+for (id, pr) in prs.items():
+    # Status strings.
+    merged_indicator = "✗"
+    pr_identifier = f"{owner}/{repo}#{pr['number']}"
+
+    # If all merge criteria pass, PR should be ready to merge.
+    if pr["mergeable"] == "MERGEABLE" and pr["mergeStateStatus"] == "CLEAN":
+        merged_indicator = "✓"
+
+    # List the status of the pull request before attempting to merge.
+    print(f" {merged_indicator:19}| {pr_identifier:23}| {str(pr['mergeable']):11}| {pr['mergeStateStatus']:10}")
+
+    # Attempt to merge the PR if ready.
+    if merged_indicator == "✓":
+        bot.graphql(MERGE_MUTATION, input={
+            "input": {
+                "pullRequestId": id,
+                "mergeMethod": "REBASE"
+            }
+        })


### PR DESCRIPTION
Converts the auto-merge bot action to use pure GraphQL, and to run as a scheduled action on implementing repos.

This is purely additive; the existing bot functionality should continue to work. If used, this action would simply run all the PR-related scripts when a pull request target event happens.