### PR TITLE
Fix some logic errors in sprint board cleanup

### DIFF
--- a/enarx-post-sprint-cleanup
+++ b/enarx-post-sprint-cleanup
@@ -17,11 +17,18 @@ for assigned_card in sprint_columns['Assigned'].get_cards():
         # If a valid issue, we want to move it to Nominated in Planning.
         # First, check if a card for this issue already exists. If yes, move it
         # instead of creating a new card.
-        for column in planning_columns:
+        found = False
+        for (key, column) in planning_columns.items():
+            if found:
+                continue
             for card in column.get_cards():
                 if card.get_content("Issue") is not None and card.get_content("Issue").id == issue.id:
+                    found = True
                     card.move(position="bottom", column=planning_columns['Nominated'])
+                    assigned_card.delete()
                     continue
+        if found:
+            continue
         # If the loop didn't find any matching cards, create a new one.
         enarxbot.create_card(planning_columns['Nominated'], issue.id, "Issue")
 


### PR DESCRIPTION
1) If a card already existed on the Planning board, the corresponding card on the Sprint board would not get deleted.
2) If a card did exist on the Planning board, the loop would not break out correctly, and the bot would attempt to add the same card again.

Given the bot fails project card additions gracefully now, this might actually not change functionality. But it should save some API calls.