### PR TITLE
Fix 404 error when attempting to fetch assigned issues/PRs

### DIFF
--- a/enarx-assigned
+++ b/enarx-assigned
@@ -2,23 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import enarxbot
+import github
 
-github = enarxbot.connect()
-org = github.get_organization('enarx')
+g = enarxbot.connect()
+org = g.get_organization('enarx')
 
 sprint = {p.name: p for p in org.get_projects(state='open')}['Sprint']
 sprint_columns = {c.name: c for c in sprint.get_columns()}
 planning = {p.name: p for p in org.get_projects(state='open')}['Planning']
 planning_columns = {c.name: c for c in planning.get_columns()}
 
-assigned_issues = [p.get_content("Issue").id for p in planning_columns['Assigned'].get_cards() if p.get_content("Issue") is not None]
-assigned_prs = [p.get_content("PullRequest").id for p in planning_columns['Assigned'].get_cards() if p.get_content("PullRequest") is not None]
+assigned_issues = [p.get_content("Issue").id for p in planning_columns['Assigned'].get_cards() if p.get_content() is github.Issue.Issue]
+assigned_prs = [p.get_content("PullRequest").id for p in planning_columns['Assigned'].get_cards() if p.get_content() is github.PullRequest.PullRequest]
 
-for issue in github.search_issues(f"org:enarx is:issue state:open is:public -label:conference -project:enarx/{sprint.number}"):
+for issue in g.search_issues(f"org:enarx is:issue state:open is:public -label:conference -project:enarx/{sprint.number}"):
     if issue.id in assigned_issues and issue.assignee is not None:
         enarxbot.create_card(sprint_columns['Assigned'], issue.id, 'Issue')
 
-for issue in github.search_issues(f"org:enarx is:pr state:open is:public -project:enarx/{sprint.number}"):
+for issue in g.search_issues(f"org:enarx is:pr state:open is:public -project:enarx/{sprint.number}"):
     # Converting issues to PR messes with ID. Store it for later before doing so.
     pr_id = issue.id
     pr = issue.as_pull_request()


### PR DESCRIPTION
Attempting to fetch card content of a specific type (ex: `Issue` ) would result in a 404 if the card didn't have that content (ex. if the card was a `PullRequest`). This patch fetches the content without specifying type and then checks its type directly in code.