### PR TITLE
Support arbitrary amounts of GraphQL depagination in a single request

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,6 +3,7 @@
 import requests
 import json
 import os
+import types
 
 PROJECTS = {
     'Conferences': 'MDc6UHJvamVjdDQ5OTI0MzM=',
@@ -43,25 +44,51 @@ class GraphQLError(Exception):
     def __init__(self, errors):
         self.errors = errors
 
-# A depagination example: fetch all PR numbers for enarx/enarx.
+# A multiple, nested depagination example: fetch all issues, PRs, and PR
+# timeline items in enarx/enarx.
 #
 # query = """
-# query($owner:String!, $name:String!, $cursor:String) {
+# query($owner:String!, $name:String!, $cursor1:String, $cursor2:String, $cursor3:String) {
 #   repository(owner:$owner, name:$name) {
-#     pullRequests(first:100, after:$cursor) {
+#     issues(first:100, after:$cursor1) {
 #       pageInfo { endCursor hasNextPage }
 #       nodes {
 #         number
+#       }
+#     }
+#     pullRequests(first:100, after:$cursor2) {
+#       pageInfo { endCursor hasNextPage }
+#       nodes {
+#         timelineItems(first:100, after:$cursor3) {
+#           pageInfo { endCursor hasNextPage }
+#           nodes {
+#             __typename
+#           }
+#         }
 #       }
 #     }
 #   }
 # }
 # """
 #
-# data = graphql(query, page=["repository", "pullRequests"], owner="enarx", name="enarx")
+# cursors = {
+#     'cursor1': {
+#         'path': ["repository", "issues"],
+#     },
+#     'cursor2': {
+#         'path': ["repository", "pullRequests"],
+#         'next': {
+#             'cursor3': {
+#                 'path': ["timelineItems"],
+#             }
+#         }
+#     }
+# }
+#
+# data = graphql(query, cursors=cursors, owner="enarx", name="enarx")
 #
 # Your query:
-#   * MUST have a `$cursor:String` variable
+#   * MUST have a `$cursor:String` variable (it MUST NOT be required!)
 #   * MUST specify `after: $cursor` correctly
 #   * MUST fetch `pageInfo { endCursor hasNextPage }`
 #   * MUST have a `nodes` entity on the pagination object
@@ -69,7 +96,7 @@ class GraphQLError(Exception):
 #
 # The results of depagination are merged. Therefore, you receive one big output list.
 # Similarly, the `pageInfo` object is removed from the result.
-def graphql(query, page=None, **kwargs):
+def graphql(query, cursors=None, prev_path=None, **kwargs):
     "Perform a GraphQL query."
     url = os.environ.get("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
 
@@ -92,18 +119,78 @@ def graphql(query, page=None, **kwargs):
     data = data["data"]
 
     # Do depagination.
-    if page is not None:
+    if cursors is None:
+        return data
+    for cursor in cursors.keys():
+        # Cursors can simply be path lists. If they are, convert to dict.
+        if isinstance(cursors[cursor], list):
+            cursors[cursor] = {
+                "path": cursors[cursor]
+            }
+        current_path = cursors[cursor]['path']
+        if prev_path:
+            current_path = prev_path + current_path
+
         obj = data
-        for name in page:
+        for name in current_path:
             obj = obj[name]
 
         pi = obj.pop("pageInfo")
         if pi["hasNextPage"]:
-            kwargs["cursor"] = pi["endCursor"]
-            next = graphql(query, page, **kwargs)
-            for name in page:
+            kwargs[cursor] = pi["endCursor"]
+            next = graphql(query, cursors={cursor:cursors[cursor]}, prev_path=prev_path, **kwargs)
+            for name in current_path:
                 next = next[name]
 
             obj["nodes"].extend(next["nodes"])
 
+        # If there are nested cursors, depaginate them too.
+        if cursors[cursor].get('next') is not None and not pi["hasNextPage"]:
+            for i in range(len(obj["nodes"])):
+                if not prev_path:
+                    current_path_nodes = current_path.copy()
+                else:
+                    current_path_nodes = prev_path.copy()
+
+                current_path_nodes += ["nodes", i]
+
+                # First, check if another recursive call is necessary to
+                # fully depaginate.
+                # This happens when
+                # 1) a nested cursor has further nested cursors
+                # 2) a nested cursor has more than one page
+                node_data = data
+                for name in current_path_nodes:
+                    node_data = node_data[name]
+
+                call_required = False
+                for next_cursor in cursors[cursor]['next']:
+                    if isinstance(cursors[cursor]['next'][next_cursor], list):
+                        cursors[cursor]['next'][next_cursor] = {
+                            "path": cursors[cursor]['next'][next_cursor]
+                        }
+                    page_to_check = node_data
+                    for name in cursors[cursor]['next'][next_cursor]['path']:
+                        page_to_check = page_to_check[name]
+
+                    hasNextPage = page_to_check['pageInfo']['hasNextPage']
+                    nextNextCursor = cursors[cursor]['next'][next_cursor].get('next')
+                    if hasNextPage or nextNextCursor is not None:
+                        call_required = True
+                if not call_required:
+                    continue
+
+                # If another call is required, make it.
+                next = graphql(query, cursors=cursors[cursor]['next'], prev_path=current_path_nodes, **kwargs)
+
+                # Weld the depaginated data together.
+                for next_cursor in cursors[cursor]['next']:
+                    join_path = current_path_nodes + cursors[cursor]['next'][next_cursor]['path']
+
+                    obj_nested = data
+                    next_nested = next
+                    for name in join_path:
+                        obj_nested = obj_nested[name]
+                        next_nested = next_nested[name]
+                    obj_nested["nodes"] = next_nested["nodes"]
     return data

--- a/enarxbot-triage
+++ b/enarxbot-triage
@@ -61,7 +61,9 @@ result = bot.graphql(
     }
     """,
     id=id,
-    page=["node", "projectCards"]
+    cursors={
+        'cursor': ["node", "projectCards"]
+    },
 )
 
 cards = result["node"]["projectCards"]["nodes"]


### PR DESCRIPTION
This should allow us to specify as many GraphQL depagination fields as we want in a single request, including nested depagination.