### PR TITLE
Make enarxbot-pr-triage run and work on issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ runs:
       shell: bash
     - run: cat $GITHUB_EVENT_PATH
       shell: bash
-    - run: $GITHUB_ACTION_PATH/enarxbot-pr-triage
+    - run: $GITHUB_ACTION_PATH/enarxbot-triage
       shell: bash

--- a/enarxbot-triage
+++ b/enarxbot-triage
@@ -7,7 +7,7 @@ import json
 import sys
 import os
 
-if os.environ["GITHUB_EVENT_NAME"] != "pull_request_target":
+if os.environ["GITHUB_EVENT_NAME"] not in ["pull_request_target", "issues"]:
     sys.exit(0)
 
 with open(os.environ["GITHUB_EVENT_PATH"]) as f:
@@ -16,14 +16,32 @@ with open(os.environ["GITHUB_EVENT_PATH"]) as f:
 if event["action"] not in {"opened", "reopened"}:
     sys.exit(0)
 
-pr = event['pull_request']['node_id']
+id = event['pull_request']['node_id']
+if id is None:
+    id = event['issue']['node_id']
 
-# Find out what projects the PR is in.
+# Find out what projects the issue/PR is in.
 result = bot.graphql(
     """
-    query($pr:ID!, $cursor:String) {
-        node(id:$pr) {
+    query($id:ID!, $cursor:String) {
+        node(id:$id) {
             ... on PullRequest {
+                projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
+                    pageInfo { endCursor hasNextPage }
+                    nodes {
+                        id
+                        column {
+                            id
+                            name
+                            project {
+                                id
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+            ... on Issue {
                 projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
                     pageInfo { endCursor hasNextPage }
                     nodes {
@@ -42,7 +60,7 @@ result = bot.graphql(
         }
     }
     """,
-    pr=pr,
+    id=id,
     page=["node", "projectCards"]
 )
 
@@ -61,6 +79,6 @@ if bot.PROJECTS["Planning"] not in projects:
         """,
         input={
             "projectColumnId": bot.COLUMNS["Planning"]["Triage"],
-            "contentId": pr
+            "contentId": id
         }
     )


### PR DESCRIPTION
The `enarxbot-pr-triage` action currently in the repo only worked on pull requests. This should make it work on issues as well.

The GraphQL data returned is structured the same regardless of the event that triggered it, so there's not much change to the logic at all -- just some generalization renames, as well as making it run and accept issue events.