### PR TITLE
Fix a bug preventing PRs from appearing on the Sprint board

### DIFF
--- a/enarx-assigned
+++ b/enarx-assigned
@@ -13,7 +13,6 @@ planning = {p.name: p for p in org.get_projects(state='open')}['Planning']
 planning_columns = {c.name: c for c in planning.get_columns()}
 
 assigned_issues = [p.get_content("Issue").id for p in planning_columns['Assigned'].get_cards() if type(p.get_content()) is github.Issue.Issue]
-assigned_prs = [p.get_content("PullRequest").id for p in planning_columns['Assigned'].get_cards() if type(p.get_content()) is github.PullRequest.PullRequest]
 
 for issue in g.search_issues(f"org:enarx is:issue state:open is:public -label:conference -project:enarx/{sprint.number}"):
     if issue.id in assigned_issues and issue.assignee is not None:
@@ -24,5 +23,5 @@ for issue in g.search_issues(f"org:enarx is:pr state:open is:public -project:ena
     pr_id = issue.id
     pr = issue.as_pull_request()
 
-    if pr_id in assigned_prs and pr.assignee is not None:
+    if pr.assignee is not None:
         enarxbot.create_card(sprint_columns['Reviewing'], pr.id, 'PullRequest')


### PR DESCRIPTION
A while back, we made a change to the `enarx-assigned` action to prevent assigned issues from moving to the Sprint board unless they were in the Assigned column (see [here](https://github.com/enarx/bot/pull/20)). At the time, I also made the same change for PRs. However, given our end-of-sprint board cleanup only touches issues and not PRs, this was ultimately redundant. Additionally, it may have inadvertently prevented some PRs from being moved to the "Reviewing" column, which is not ideal.

This fixes that bug by reverting the changes made in the mentioned patch just for pull requests, and thus making it such that all assigned PRs on the Planning board also get added to the Sprint board's "Reviewing" column. This shouldn't impact sprint or board functionality; in fact, it's probably better, since we consider PRs always-urgent anyway.