### PR TITLE
Make insufficient repo permissions a soft failure

### DIFF
--- a/enarx-pr-assign
+++ b/enarx-pr-assign
@@ -83,6 +83,6 @@ for issue in enarxbot.connect().search_issues(f"org:enarx is:pr is:public is:ope
     print()
 
     if remove:
-        pr.remove_from_assignees(*remove)
+        enarxbot.remove_from_assignees(pr, remove)
     if needed:
-        pr.add_to_assignees(*needed)
+        enarxbot.add_to_assignees(pr, needed)

--- a/enarx-pr-request
+++ b/enarx-pr-request
@@ -67,4 +67,4 @@ for issue in github.search_issues(f"org:enarx is:pr is:public is:open -is:draft"
     print()
 
     # With all three selected, request them as reviewers.
-    pr.create_review_request(reviewers=list(requesting - requested))
+    enarxbot.review_request(pr, reviewers=list(requesting - requested))

--- a/enarxbot.py
+++ b/enarxbot.py
@@ -129,6 +129,33 @@ def merge(pr):
         print(f"PR {pr.number} needs attention from the author. Assigning.")
         pr.add_to_assignees([pr.user.login])
 
+def review_request(pr, reviewers):
+    try:
+        pr.create_review_request(reviewers)
+    except github.GithubException as e:
+        error = e.data["message"]
+        if error != "Must have admin rights to Repository.":
+            raise
+        print(f"Enarxbot does not have correct permissions on this repo.")
+
+def add_to_assignees(pr, additions):
+    try:
+        pr.add_to_assignees(*additions)
+    except github.GithubException as e:
+        error = e.data["message"]
+        if error != "Must have admin rights to Repository.":
+            raise
+        print(f"Enarxbot does not have correct permissions on this repo.")
+
+def remove_from_assignees(pr, removals):
+    try:
+        pr.add_to_assignees(*removals)
+    except github.GithubException as e:
+        error = e.data["message"]
+        if error != "Must have admin rights to Repository.":
+            raise
+        print(f"Enarxbot does not have correct permissions on this repo.")
+
 # Get all issue numbers related to a PR.
 def get_related_issues(pr):
     # Regex to pick out closing keywords.


### PR DESCRIPTION
This should be a quick band-aid for the current bot failures.

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
