### PR TITLE
Prevent the bot from attempting to assign dependabot to PRs

### DIFF
--- a/enarx-pr-assign
+++ b/enarx-pr-assign
@@ -75,6 +75,9 @@ for issue in enarxbot.connect().search_issues(f"org:enarx is:pr is:public is:ope
     remove = assignees - responsible
     needed = responsible - assignees
 
+    if "dependabot[bot]" in needed:
+        needed.remove("dependabot[bot]")
+
     print(f"{slug}:", end='')
     for u in needed:
         print(f" +{u}", end='')


### PR DESCRIPTION
Band-aid fix, for now.