### PR TITLE
Added badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
+![hourly](https://github.com/enarx/bot/workflows/hourly/badge.svg)
+![cleanup-sprint-board](https://github.com/enarx/bot/workflows/cleanup-sprint-board/badge.svg)
+[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/enarx/bot.svg)](http://isitmaintained.com/project/enarx/bot "Average time to resolve an issue")
+[![Percentage of issues still open](http://isitmaintained.com/badge/open/enarx/bot.svg)](http://isitmaintained.com/project/enarx/bot "Percentage of issues still open")
+
 # enarxbot
 I'm a bot. Bleep. Blorp.


### PR DESCRIPTION
Closes #50 

Implemented a few badges to reflect to status of enarx/bot

<!-- 
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #123" or "Resolves enarx/repo-name#123", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
