### PR TITLE
Fix post-sprint-cleanup not checking out the repo properly

### DIFF
--- a/.github/workflows/sprint-board-cleanup.yml
+++ b/.github/workflows/sprint-board-cleanup.yml
@@ -7,5 +7,7 @@ jobs:
   manual:
     runs-on: ubuntu-latest
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
     - name: post-sprint-cleanup
       run: enarxbot-post-sprint-cleanup


### PR DESCRIPTION
This was causing `enarxbot-post-sprint-cleanup` to fail.