### PR TITLE
Require a properly-set BOT_TOKEN environment variable to run automation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -44,6 +44,10 @@ class GraphQLError(Exception):
     def __init__(self, errors):
         self.errors = errors
 
+class TokenError(Exception):
+    def __init__(self, error):
+        self.error = error
+
 # A multiple, nested depagination example: fetch all issues, PRs, and PR
 # timeline items in enarx/enarx.
 #
@@ -101,11 +105,17 @@ def graphql(query, cursors=None, prev_path=None, **kwargs):
     url = os.environ.get("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
 
     params = { "query": query.strip(), "variables": json.dumps(kwargs) }
-    token = os.environ.get('GITHUB_TOKEN', None)
+    token = os.environ.get('BOT_TOKEN', None)
     headers = {}
 
     if token is not None:
         headers["Authorization"] = f"token {token}"
+    else:
+        raise TokenError(error="""
+BOT_TOKEN is unset. If you wish to opt in to bot automation, provide an
+appropriately-scoped personal access token as a shared secret named
+BOT_TOKEN.
+    """)
 
     # Opt into preview API fields for PR merge status.
     headers["Accept"] = "application/vnd.github.merge-info-preview+json"

--- a/enarxbot-assigned
+++ b/enarxbot-assigned
@@ -28,65 +28,69 @@ else:
 
 
 # Find out what projects the issue/PR is in, as well as their assignees.
-result = bot.graphql(
-    """
-    query($id:ID!, $cardCursor:String, $assigneeCursor:String) {
-        node(id:$id) {
-            ... on PullRequest {
-                number
-                assignees(first:100, after:$assigneeCursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        login
+try:
+    result = bot.graphql(
+        """
+        query($id:ID!, $cardCursor:String, $assigneeCursor:String) {
+            node(id:$id) {
+                ... on PullRequest {
+                    number
+                    assignees(first:100, after:$assigneeCursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
+                            login
+                        }
                     }
-                }
-                projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cardCursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        id
-                        column {
+                    projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cardCursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
                             id
-                            name
-                            project {
+                            column {
                                 id
                                 name
+                                project {
+                                    id
+                                    name
+                                }
                             }
                         }
                     }
                 }
-            }
-            ... on Issue {
-                number
-                assignees(first:100, after:$assigneeCursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        login
+                ... on Issue {
+                    number
+                    assignees(first:100, after:$assigneeCursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
+                            login
+                        }
                     }
-                }
-                projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cardCursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        id
-                        column {
+                    projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cardCursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
                             id
-                            name
-                            project {
+                            column {
                                 id
                                 name
+                                project {
+                                    id
+                                    name
+                                }
                             }
                         }
                     }
                 }
             }
         }
-    }
-    """,
-    id=id,
-    page={
-        "cardCursor": ["node", "projectCards"],
-        "assigneeCursor": ["node", "assignees"],
-    }
-)
+        """,
+        id=id,
+        page={
+            "cardCursor": ["node", "projectCards"],
+            "assigneeCursor": ["node", "assignees"],
+        }
+    )
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 # Construct lists of assignees, projects, and columns.
 assignees = result["node"]["assignees"]["nodes"]

--- a/enarxbot-copy-labels-linked
+++ b/enarxbot-copy-labels-linked
@@ -99,13 +99,17 @@ owner, repo = os.environ["GITHUB_REPOSITORY"].split("/")
 id = event['pull_request']['node_id']
 
 # Get PR data and open issues in the repo.
-result = bot.graphql(
-    QUERY,
-    id=id,
-    org=owner,
-    repo=repo,
-    cursors=QUERY_CURSORS
-)
+try:
+    result = bot.graphql(
+        QUERY,
+        id=id,
+        org=owner,
+        repo=repo,
+        cursors=QUERY_CURSORS
+    )
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 # Create a lookup table for issue labels by number.
 issue_to_labels = {i['number']: i['labels']['nodes'] for i in result['repository']['issues']['nodes']}

--- a/enarxbot-post-sprint-cleanup
+++ b/enarxbot-post-sprint-cleanup
@@ -76,12 +76,16 @@ if os.environ["GITHUB_EVENT_NAME"] != "workflow_dispatch":
     sys.exit(0)
 
 # Query all cards in two columns: the assigned columns of both Planning and Sprint.
-result = bot.graphql(
-    QUERY,
-    planningColumnId=bot.COLUMNS['Planning']['Assigned'],
-    sprintColumnId=bot.COLUMNS['Sprint']['Assigned'],
-    cursors=QUERY_CURSORS
-)
+try:
+    result = bot.graphql(
+        QUERY,
+        planningColumnId=bot.COLUMNS['Planning']['Assigned'],
+        sprintColumnId=bot.COLUMNS['Sprint']['Assigned'],
+        cursors=QUERY_CURSORS
+    )
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 # Create sets of issue IDs that are in each column. Also create lookup tables
 # for corresponding card IDs for API actions.

--- a/enarxbot-pr-assign
+++ b/enarxbot-pr-assign
@@ -145,7 +145,11 @@ if os.environ["GITHUB_EVENT_NAME"] != "schedule":
 
 org, repo = os.environ["GITHUB_REPOSITORY"].split("/")
 
-pr_data = bot.graphql(QUERY, org=org, repo=repo, cursor=QUERY_CURSORS)
+try:
+    pr_data = bot.graphql(QUERY, org=org, repo=repo, cursor=QUERY_CURSORS)
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 # Create a login:id lookup table.
 login_to_id = {u["login"]: u["id"] for u in iterusers(pr_data)}

--- a/enarxbot-pr-merge
+++ b/enarxbot-pr-merge
@@ -36,7 +36,12 @@ if os.environ["GITHUB_EVENT_NAME"] != "schedule":
 
 owner, repo = os.environ["GITHUB_REPOSITORY"].split("/")
 cursors = {"cursor": ["repository", "pullRequests"]}
-result = bot.graphql(MERGEABLE_QUERY, cursors=cursors, owner=owner, repo=repo)
+
+try:
+    result = bot.graphql(MERGEABLE_QUERY, cursors=cursors, owner=owner, repo=repo)
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 prs = {i["id"]: i for i in result["repository"]["pullRequests"]["nodes"]}
 

--- a/enarxbot-pr-request
+++ b/enarxbot-pr-request
@@ -117,7 +117,11 @@ pr = event['pull_request']['node_id']
 org = event['organization']['node_id']
 
 # Query the PR for all relevant users and status info.
-pr_data = bot.graphql(QUERY_PR, pr=pr, team="reviews", cursors=QUERY_PR_CURSORS)
+try:
+    pr_data = bot.graphql(QUERY_PR, pr=pr, team="reviews", cursors=QUERY_PR_CURSORS)
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 # Create lookup tables for ease of use.
 login_to_id = {u["login"]: u["id"] for u in iterusers(pr_data)}

--- a/enarxbot-triage
+++ b/enarxbot-triage
@@ -22,52 +22,56 @@ id = event.get('pull_request', event.get('issue'))
 id = id['node_id']
 
 # Find out what projects the issue/PR is in.
-result = bot.graphql(
-    """
-    query($id:ID!, $cursor:String) {
-        node(id:$id) {
-            ... on PullRequest {
-                number
-                projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        id
-                        column {
+try:
+    result = bot.graphql(
+        """
+        query($id:ID!, $cursor:String) {
+            node(id:$id) {
+                ... on PullRequest {
+                    number
+                    projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
                             id
-                            name
-                            project {
+                            column {
                                 id
                                 name
+                                project {
+                                    id
+                                    name
+                                }
                             }
                         }
                     }
                 }
-            }
-            ... on Issue {
-                number
-                projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
-                    pageInfo { endCursor hasNextPage }
-                    nodes {
-                        id
-                        column {
+                ... on Issue {
+                    number
+                    projectCards(first:100, archivedStates:NOT_ARCHIVED, after:$cursor) {
+                        pageInfo { endCursor hasNextPage }
+                        nodes {
                             id
-                            name
-                            project {
+                            column {
                                 id
                                 name
+                                project {
+                                    id
+                                    name
+                                }
                             }
                         }
                     }
                 }
             }
         }
-    }
-    """,
-    id=id,
-    cursors={
-        'cursor': ["node", "projectCards"]
-    },
-)
+        """,
+        id=id,
+        cursors={
+            'cursor': ["node", "projectCards"]
+        },
+    )
+except bot.TokenError as e:
+    print(e.error)
+    sys.exit(0)
 
 cards = result["node"]["projectCards"]["nodes"]
 projects = {card["column"]["project"]["id"] for card in cards}


### PR DESCRIPTION
This should make the bot explicitly opt-in for things like forks. If `BOT_TOKEN` is not set, all running scripts will fail gracefully, with a message explaining how to opt in using a properly-provisioned token.

Note this is a breaking change, and will require workflows using the Enarxbot to be updated to not overwrite `GITHUB_TOKEN`.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>