### PR TITLE
Fix a bug with BOT_TOKEN requirement

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -108,7 +108,7 @@ def graphql(query, cursors=None, prev_path=None, **kwargs):
     token = os.environ.get('BOT_TOKEN', None)
     headers = {}
 
-    if token is not None:
+    if token is not None and len(token) > 0:
         headers["Authorization"] = f"token {token}"
     else:
         raise TokenError(error="""


### PR DESCRIPTION
Even if the `BOT_TOKEN` secret itself is unset, the environment variable would be set, but empty. This updates the token validity check to account for that: the token must also be longer than 0 in length in order to proceed.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>
