### PR TITLE
Fix race condition when moving PRs to sprint board

### DIFF
--- a/enarxbot-assigned
+++ b/enarxbot-assigned
@@ -120,13 +120,18 @@ if len(assignees) > 0 and bot.PROJECTS["Sprint"] not in columns.keys():
 
 # If this issue/PR needs to be moved, move it.
 if input is not None:
-    bot.graphql(
-        """
-        mutation($input:AddProjectCardInput!) {
-            addProjectCard(input:$input) {
-                clientMutationId
+    try:
+        bot.graphql(
+            """
+            mutation($input:AddProjectCardInput!) {
+                addProjectCard(input:$input) {
+                    clientMutationId
+                }
             }
-        }
-        """,
-        input=input
-    )
+            """,
+            input=input
+        )
+    except bot.GraphQLError as e:
+        if e["message"] != "Project already has the associated issue":
+            raise
+        print(f"Project already has this card. Skipping addition.")


### PR DESCRIPTION
When `enarx-pr-assign` runs, it often assigns three people at once when a PR is first opened. This fires three separate `pull_request_target` `assigned` events. If that PR is not on the sprint board, this scenario causes a race condition between all three events, which causes a failure when one of the events attempts to add a card that's already present.

This just makes project addition errors a soft failure. Short of a mutex across different Actions, this is the best solution.

See [here](https://github.com/enarx/bot/runs/1344462942?check_suite_focus=true) for an example failure this would fix.