### PR TITLE
Fix unset BOT_TOKEN for sprint board cleanup

### DIFF
--- a/.github/workflows/sprint-board-cleanup.yml
+++ b/.github/workflows/sprint-board-cleanup.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   manual:
     runs-on: ubuntu-latest
+    env:
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Hopefully the last fix.
