### PR TITLE
Fix bug w/ project card error handling and apply to both actions

### DIFF
--- a/enarxbot-assigned
+++ b/enarxbot-assigned
@@ -132,6 +132,6 @@ if input is not None:
             input=input
         )
     except bot.GraphQLError as e:
-        if e["message"] != "Project already has the associated issue":
+        if e.errors[0]["message"] != "Project already has the associated issue":
             raise
         print(f"Project already has this card. Skipping addition.")

--- a/enarxbot-triage
+++ b/enarxbot-triage
@@ -82,16 +82,21 @@ if bot.PROJECTS["Planning"] not in projects:
     print(f"Adding {owner}/{repo}#{result['node']['number']} to Planning board")
 
     # Add the content to the project.
-    bot.graphql(
-        """
-        mutation($input:AddProjectCardInput!) {
-            addProjectCard(input:$input) {
-                clientMutationId
+    try:
+        bot.graphql(
+            """
+            mutation($input:AddProjectCardInput!) {
+                addProjectCard(input:$input) {
+                    clientMutationId
+                }
             }
-        }
-        """,
-        input={
-            "projectColumnId": bot.COLUMNS["Planning"]["Triage"],
-            "contentId": id
-        }
-    )
+            """,
+            input={
+                "projectColumnId": bot.COLUMNS["Planning"]["Triage"],
+                "contentId": id
+            }
+        )
+    except bot.GraphQLError as e:
+        if e.errors[0]["message"] != "Project already has the associated issue":
+            raise
+        print(f"Project already has this card. Skipping addition.")


### PR DESCRIPTION
`GraphQLError` was not being handled correctly when thrown in `enarxbot-assigned`. That has been fixed, and the error handling has also been extended to `enarxbot-triage`, which may perform the same API call but didn't have error handling on it.