### PR TITLE
Store project/column IDs locally instead of upstream

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,30 @@
+PROJECTS = {
+    'Conferences': 'MDc6UHJvamVjdDQ5OTI0MzM=',
+    'Planning': 'MDc6UHJvamVjdDQ5NjA4NDg=',
+    'Sprint': 'MDc6UHJvamVjdDQ4MjA5OTM='
+}
+
+COLUMNS = {
+    'Conferences': {
+        'Accepted': 'MDEzOlByb2plY3RDb2x1bW4xMDA1NzA1Ng==',
+        'Completed': 'MDEzOlByb2plY3RDb2x1bW4xMDA1NzA1OQ==',
+        'Considering': 'MDEzOlByb2plY3RDb2x1bW4xMDA1NzA0OQ==',
+        'Delivered': 'MDEzOlByb2plY3RDb2x1bW4xMDA1NzA1Nw==',
+        'Submitted': 'MDEzOlByb2plY3RDb2x1bW4xMDA1NzA1Mw=='
+    },
+    'Planning': {
+        'Accepted': 'MDEzOlByb2plY3RDb2x1bW4xMDAwMzg0OQ==',
+        'Assigned': 'MDEzOlByb2plY3RDb2x1bW4xMDAwODk1MQ==',
+        'Backlog': 'MDEzOlByb2plY3RDb2x1bW4xMDAwMzg0Nw==',
+        'Done': 'MDEzOlByb2plY3RDb2x1bW4xMDAwOTI3OA==',
+        'Nominated': 'MDEzOlByb2plY3RDb2x1bW4xMDAwMzg0OA==',
+        'Triage': 'MDEzOlByb2plY3RDb2x1bW4xMDAwMzg0MA=='
+    },
+    'Sprint': {
+        'Active': 'MDEzOlByb2plY3RDb2x1bW4xMDQxMTcwOA==',
+        'Assigned': 'MDEzOlByb2plY3RDb2x1bW45ODA1MjQ5',
+        'Done': 'MDEzOlByb2plY3RDb2x1bW45ODA0Mzc2',
+        'Reviewed': 'MDEzOlByb2plY3RDb2x1bW4xMDQxMTcyMg==',
+        'Reviewing': 'MDEzOlByb2plY3RDb2x1bW45ODA1MjY1'
+    }
+}

--- a/enarxbot-assigned
+++ b/enarxbot-assigned
@@ -3,6 +3,7 @@
 
 from githubgql import githubgql
 
+import constants
 import json
 import sys
 import os
@@ -99,14 +100,14 @@ columns = {card["column"]["project"]["id"]: card["column"]["name"] for card in c
 
 input = None
 
-if len(assignees) > 0 and githubgql.PROJECTS["Sprint"] not in columns.keys():
+if len(assignees) > 0 and constants.PROJECTS["Sprint"] not in columns.keys():
     # Issues must additionally be present in the "Assigned" column of the
     # Planning board to be moved.
-    if id_type == "issue" and columns.get(githubgql.PROJECTS["Planning"]) == "Assigned":
+    if id_type == "issue" and columns.get(constants.PROJECTS["Planning"]) == "Assigned":
         # Print status.
         print(f"Moving issue {owner}/{repo}#{result['node']['number']} to Sprint board")
         input = {
-            "projectColumnId": githubgql.COLUMNS["Sprint"]["Assigned"],
+            "projectColumnId": constants.COLUMNS["Sprint"]["Assigned"],
             "contentId": id
         }
 
@@ -114,7 +115,7 @@ if len(assignees) > 0 and githubgql.PROJECTS["Sprint"] not in columns.keys():
         # Print status.
         print(f"Moving PR {owner}/{repo}#{result['node']['number']} to Sprint board")
         input = {
-            "projectColumnId": githubgql.COLUMNS["Sprint"]["Reviewing"],
+            "projectColumnId": constants.COLUMNS["Sprint"]["Reviewing"],
             "contentId": id
         }
 

--- a/enarxbot-post-sprint-cleanup
+++ b/enarxbot-post-sprint-cleanup
@@ -3,6 +3,7 @@
 
 from githubgql import githubgql
 
+import constants
 import json
 import sys
 import os
@@ -79,8 +80,8 @@ if os.environ["GITHUB_EVENT_NAME"] != "workflow_dispatch":
 try:
     result = githubgql.graphql(
         QUERY,
-        planningColumnId=githubgql.COLUMNS['Planning']['Assigned'],
-        sprintColumnId=githubgql.COLUMNS['Sprint']['Assigned'],
+        planningColumnId=constants.COLUMNS['Planning']['Assigned'],
+        sprintColumnId=constants.COLUMNS['Sprint']['Assigned'],
         cursors=QUERY_CURSORS
     )
 except githubgql.TokenError as e:
@@ -102,7 +103,7 @@ for content in sprint_content:
         githubgql.graphql(
             MOVE_CARD_MUTATION,
             input={
-                "columnId": githubgql.COLUMNS["Planning"]["Nominated"],
+                "columnId": constants.COLUMNS["Planning"]["Nominated"],
                 "cardId": planning_content_cards[content]
             }
         )
@@ -110,7 +111,7 @@ for content in sprint_content:
         githubgql.graphql(
             ADD_CARD_MUTATION,
             input={
-                "projectColumnId": githubgql.COLUMNS["Planning"]["Nominated"],
+                "projectColumnId": constants.COLUMNS["Planning"]["Nominated"],
                 "contentId": content
             }
         )

--- a/enarxbot-triage
+++ b/enarxbot-triage
@@ -3,6 +3,7 @@
 
 from githubgql import githubgql
 
+import constants
 import json
 import sys
 import os
@@ -77,7 +78,7 @@ cards = result["node"]["projectCards"]["nodes"]
 projects = {card["column"]["project"]["id"] for card in cards}
 
 # If the issue/PR isn't in the Planning project, add it to Triage.
-if githubgql.PROJECTS["Planning"] not in projects:
+if constants.PROJECTS["Planning"] not in projects:
     # Print status.
     print(f"Adding {owner}/{repo}#{result['node']['number']} to Planning board")
 
@@ -92,7 +93,7 @@ if githubgql.PROJECTS["Planning"] not in projects:
             }
             """,
             input={
-                "projectColumnId": githubgql.COLUMNS["Planning"]["Triage"],
+                "projectColumnId": constants.COLUMNS["Planning"]["Triage"],
                 "contentId": id
             }
         )


### PR DESCRIPTION
This will allow the upstream `githubgql` library to remove them.

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
